### PR TITLE
feat(US-8.2): Wire version history panel into design detail view

### DIFF
--- a/frontend/src/pages/DesignDetailPage.test.tsx
+++ b/frontend/src/pages/DesignDetailPage.test.tsx
@@ -28,6 +28,16 @@ vi.mock('@/components/viewer/ModelViewer', () => ({
   ),
 }));
 
+// Mock the VersionHistoryPanel component
+vi.mock('@/pages/VersionHistoryPanel', () => ({
+  VersionHistoryPanel: ({ designId, designName, onClose }: { designId: string; designName: string; onClose: () => void }) => (
+    <div data-testid="version-history-panel">
+      <span>Version History: {designName}</span>
+      <button onClick={onClose}>Close Panel</button>
+    </div>
+  ),
+}));
+
 // Mock design API
 vi.mock('@/lib/designs', () => ({
   getDesign: vi.fn(),
@@ -270,6 +280,62 @@ describe('DesignDetailPage', () => {
 
       await waitFor(() => {
         expect(screen.getByText('No preview available')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('version history', () => {
+    it('shows versions button', async () => {
+      vi.mocked(designs.getDesign).mockResolvedValue(mockDesign);
+      vi.mocked(generate.getPreviewData).mockResolvedValue(new ArrayBuffer(8));
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /versions/i })).toBeInTheDocument();
+      });
+    });
+
+    it('opens version history panel when versions button is clicked', async () => {
+      vi.mocked(designs.getDesign).mockResolvedValue(mockDesign);
+      vi.mocked(generate.getPreviewData).mockResolvedValue(new ArrayBuffer(8));
+
+      renderPage();
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /versions/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /versions/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('version-history-panel')).toBeInTheDocument();
+        expect(screen.getByText('Version History: Test Design')).toBeInTheDocument();
+      });
+    });
+
+    it('closes version history panel when close is clicked', async () => {
+      vi.mocked(designs.getDesign).mockResolvedValue(mockDesign);
+      vi.mocked(generate.getPreviewData).mockResolvedValue(new ArrayBuffer(8));
+
+      renderPage();
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /versions/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /versions/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('version-history-panel')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Close Panel'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('version-history-panel')).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/pages/DesignDetailPage.tsx
+++ b/frontend/src/pages/DesignDetailPage.tsx
@@ -14,13 +14,15 @@ import {
   Calendar,
   Folder,
   GitFork,
+  History,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { ModelViewer } from '@/components/viewer/ModelViewer';
 import { useAuth } from '@/contexts/AuthContext';
 import { getDesign, type Design } from '@/lib/designs';
 import { getPreviewData, downloadGeneratedFile } from '@/lib/generate';
+import { VersionHistoryPanel } from '@/pages/VersionHistoryPanel';
 
 export function DesignDetailPage() {
   const { designId } = useParams<{ designId: string }>();
@@ -32,41 +34,48 @@ export function DesignDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [stlData, setStlData] = useState<ArrayBuffer | null>(null);
   const [downloading, setDownloading] = useState<string | null>(null);
+  const [showVersionHistory, setShowVersionHistory] = useState(false);
 
   // Get extra_data from design
   const extraData = design?.extra_data || null;
 
+  /**
+   * Load design data and STL preview.
+   * Extracted as a callback so it can be re-invoked after version restore.
+   */
+  const loadDesign = useCallback(async () => {
+    if (!designId || !token) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getDesign(designId, token);
+      setDesign(data);
+
+      // Load STL preview if job_id exists
+      if (data.extra_data?.job_id) {
+        try {
+          const preview = await getPreviewData(String(data.extra_data.job_id), token);
+          setStlData(preview);
+        } catch {
+          console.log('No preview available');
+        }
+      } else {
+        setStlData(null);
+      }
+    } catch (err) {
+      console.error('Failed to load design:', err);
+      setError('Failed to load design. It may not exist or you do not have access.');
+    } finally {
+      setLoading(false);
+    }
+  }, [designId, token]);
+
   // Fetch design details
   useEffect(() => {
-    async function loadDesign() {
-      if (!designId || !token) return;
-      
-      setLoading(true);
-      setError(null);
-
-      try {
-        const data = await getDesign(designId, token);
-        setDesign(data);
-        
-        // Load STL preview if job_id exists
-        if (data.extra_data?.job_id) {
-          try {
-            const preview = await getPreviewData(data.extra_data.job_id, token);
-            setStlData(preview);
-          } catch {
-            console.log('No preview available');
-          }
-        }
-      } catch (err) {
-        console.error('Failed to load design:', err);
-        setError('Failed to load design. It may not exist or you do not have access.');
-      } finally {
-        setLoading(false);
-      }
-    }
-
     loadDesign();
-  }, [designId, token]);
+  }, [loadDesign]);
 
   const handleDownload = async (format: 'step' | 'stl') => {
     if (!extraData?.job_id || !token) return;
@@ -173,6 +182,13 @@ export function DesignDetailPage() {
           </div>
           
           <div className="flex gap-2">
+            <button
+              onClick={() => setShowVersionHistory(true)}
+              className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              <History className="w-4 h-4" />
+              Versions
+            </button>
             <button
               onClick={handleRemix}
               className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
@@ -294,6 +310,18 @@ export function DesignDetailPage() {
           )}
         </div>
       </div>
+      {/* Version History Panel */}
+      {showVersionHistory && design && (
+        <VersionHistoryPanel
+          designId={design.id}
+          designName={design.name}
+          onClose={() => setShowVersionHistory(false)}
+          onVersionRestore={() => {
+            // Reload design to reflect restored version
+            loadDesign();
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Wires the existing `VersionHistoryPanel` component into `DesignDetailPage`, enabling users to view version history, restore previous versions, and compare versions from the design detail view.

> **Note:** This PR is stacked on #326 (US-8.3). Merge #326 first.

## Changes

**`frontend/src/pages/DesignDetailPage.tsx`**
- Added "Versions" button with `History` icon in header action area
- Opens `VersionHistoryPanel` as slide-out panel on click
- Extracted `loadDesign` into a `useCallback` so it can be re-invoked after version restore
- Added `onVersionRestore` handler that reloads the design and preview after a restore

**`frontend/src/pages/DesignDetailPage.test.tsx`**
- Added mock for `VersionHistoryPanel`
- 3 new test cases: versions button renders, panel opens on click, panel closes

## Components Wired

The `VersionHistoryPanel` (580 lines, 15 existing tests) was already fully built with:
- Paginated version list with dates and descriptions
- "Restore" action per version
- Checkbox selection + "Compare" for side-by-side diff
- Expand/collapse for geometry details

This PR just integrates it into the design detail page.

## Testing

- **33 tests pass** (18 DesignDetailPage + 15 VersionHistoryPanel)
- TypeScript compiles cleanly

## User Story

Closes #79 — US-8.2: Version History UI (3 pts)">
