### PR TITLE
chore: tighten agent rules for temp dirs and full CI test enforcement

### DIFF
--- a/.github/agents/architecture-security.agent.md
+++ b/.github/agents/architecture-security.agent.md
@@ -99,7 +99,24 @@ If you cannot complete a task fully:
 - **DO NOT work around issues with hacks** - Escalate for proper resolution
 - **DO NOT claim completion if verification fails** - Fix the issues first
 
-### 5. NEVER Bypass Quality Checks
+### 5. NEVER Use `/tmp` or System Temp Directories
+
+**NEVER write files to `/tmp`, `/var/tmp`, or any system temporary directory.** This applies to ALL contexts: scripts, tests, CI/CD pipelines, build processes, and runtime code.
+
+**Why:**
+- `/tmp` is shared across all users and processes — creates security risks (symlink attacks, data leaks)
+- Files in `/tmp` may persist across runs, causing flaky tests and non-reproducible builds
+- CI/CD runners share `/tmp` across jobs, causing cross-contamination
+- Sensitive data written to `/tmp` may be readable by other processes
+
+**Instead, use:**
+- Python: `tempfile.mkdtemp()` or `tempfile.NamedTemporaryFile()` for auto-cleanup
+- Tests: Use pytest `tmp_path` / `tmp_path_factory` fixtures
+- TypeScript/Node: `os.tmpdir()` with unique subdirectories, or `fs.mkdtemp()`
+- Shell scripts: `mktemp -d` for unique temporary directories
+- Build artifacts: Use project-local directories (e.g., `build/`, `dist/`, `.cache/`)
+
+### 6. NEVER Bypass Quality Checks
 
 **The following are STRICTLY FORBIDDEN:**
 
@@ -113,7 +130,7 @@ If you cannot complete a task fully:
 
 **If a check fails, FIX THE ARCHITECTURE, not the rules.**
 
-### 6. Use Existing Technology Choices
+### 7. Use Existing Technology Choices
 
 **You MUST work within the established technology stack unless explicitly asked to change it.**
 
@@ -141,7 +158,7 @@ If you cannot complete a task fully:
 
 **The existing ADRs represent deliberate decisions. Respect them.**
 
-### 7. Prefer Modern Open-Source Tools
+### 8. Prefer Modern Open-Source Tools
 
 **When proposing NEW tools or infrastructure (with approval), always prefer modern, truly open-source alternatives.**
 

--- a/.github/agents/architecture-security.agent.md
+++ b/.github/agents/architecture-security.agent.md
@@ -39,7 +39,7 @@ cd backend
 ruff check .                    # Linting must pass with zero errors
 ruff format --check .           # Formatting must be correct
 mypy .                          # Type checking must pass
-pytest                          # ALL tests must pass
+pytest                          # ALL tests must pass — the ENTIRE suite, not just related tests
 pytest --cov=app --cov-fail-under=80  # Coverage must be ≥80%
 
 # Frontend verification (run ALL of these)  
@@ -47,8 +47,10 @@ cd frontend
 npm run lint                    # ESLint must pass with zero errors
 npx tsc --noEmit                # TypeScript must compile with zero errors
 npm run build                   # Build must succeed
-npm run test                    # ALL tests must pass
+npm run test                    # ALL tests must pass — the ENTIRE suite, not just related tests
 ```
+
+> **"ALL tests" means every test in the entire codebase, not just tests related to the current change.** Architectural changes can have wide-reaching impacts. A schema change, migration, or API contract modification can break tests in unrelated modules. You must verify the full suite passes.
 
 ### 2a. CI Pipeline Requirements
 
@@ -84,13 +86,14 @@ alembic current                 # Verify current state
 A task is **NOT complete** until:
 - [ ] All acceptance criteria are fully implemented (not partially)
 - [ ] All code compiles/builds without errors or warnings
-- [ ] All linting rules pass with ZERO violations
-- [ ] All type checks pass with ZERO errors
-- [ ] All existing tests continue to pass
+- [ ] All linting rules pass with ZERO violations across the **entire codebase**
+- [ ] All type checks pass with ZERO errors across the **entire codebase**
+- [ ] **Every existing test in the entire suite continues to pass** (not just tests related to your change)
 - [ ] New tests are written for all new code (≥80% coverage)
 - [ ] Documentation is updated where applicable
 - [ ] No TODO/FIXME/HACK comments left in code
 - [ ] Code review checklist is complete
+- [ ] **Full CI pipeline would pass** (lint → typecheck → all tests → build → E2E)
 
 ### 4. Failure Protocol
 

--- a/.github/agents/development.agent.md
+++ b/.github/agents/development.agent.md
@@ -58,6 +58,8 @@ npm run test                    # ALL tests must pass
 
 **If ANY verification step fails, you are NOT done. Fix it before proceeding.**
 
+> **CRITICAL: "ALL tests" means the ENTIRE test suite — not just tests related to your change.** If your change causes a pre-existing test in a completely different module to fail, **that is YOUR responsibility to fix before declaring done.** CI runs every lint rule, every type check, every unit test, every integration test, and every E2E test across the entire codebase. If any single one fails, the PR is rejected. There is no concept of "only my tests need to pass."
+
 ### 2a. CI Pipeline Requirements
 
 **Your code will be validated by the CI pipeline (`.github/workflows/ci.yml`) which runs in stages:**
@@ -89,20 +91,23 @@ cd frontend && npm run build && cd ..
 
 **CI will REJECT your PR if any stage fails. Builds will NOT run if tests fail. Tests will NOT run if lint fails.**
 
+> **You are responsible for the ENTIRE CI pipeline passing, not just the tests related to your change.** If your code change causes a failure in any test, lint rule, or type check anywhere in the codebase, you must fix it. "It was already broken" is not an acceptable excuse — if it passes on the base branch but fails with your changes, it's your problem to solve.
+
 ### 3. Definition of Done
 
 A task is **NOT complete** until ALL of the following are true:
 - [ ] All acceptance criteria are fully implemented (not partially)
 - [ ] All code compiles/builds without errors or warnings
-- [ ] All linting rules pass with ZERO violations  
-- [ ] All type checks pass with ZERO errors
-- [ ] All existing tests continue to pass
+- [ ] All linting rules pass with ZERO violations across the **entire codebase**
+- [ ] All type checks pass with ZERO errors across the **entire codebase**
+- [ ] **Every existing test in the entire suite continues to pass** (not just tests related to your change)
 - [ ] New tests written for ALL new code (≥80% coverage)
 - [ ] All edge cases handled with proper error messages
 - [ ] Documentation updated (docstrings, JSDoc, README if needed)
 - [ ] No TODO/FIXME/HACK comments left in code
 - [ ] Code is clean, readable, and follows project patterns
 - [ ] Security best practices implemented (no hardcoded secrets, input validation, etc.)
+- [ ] **Full CI pipeline would pass** (lint → typecheck → all tests → build → E2E)
 
 ### 4. Failure Protocol
 

--- a/.github/agents/development.agent.md
+++ b/.github/agents/development.agent.md
@@ -112,7 +112,24 @@ If you cannot complete a task fully:
 - **DO NOT claim completion if verification fails** - Fix ALL issues first
 - **DO NOT skip steps "to save time"** - Every step exists for a reason
 
-### 5. Anti-Patterns to AVOID
+### 5. NEVER Use `/tmp` or System Temp Directories
+
+**NEVER write files to `/tmp`, `/var/tmp`, or any system temporary directory.** This applies to ALL contexts: scripts, tests, CI/CD pipelines, build processes, and runtime code.
+
+**Why:**
+- `/tmp` is shared across all users and processes — creates security risks (symlink attacks, data leaks)
+- Files in `/tmp` may persist across runs, causing flaky tests and non-reproducible builds
+- CI/CD runners share `/tmp` across jobs, causing cross-contamination
+- Sensitive data written to `/tmp` may be readable by other processes
+
+**Instead, use:**
+- Python: `tempfile.mkdtemp()` or `tempfile.NamedTemporaryFile()` for auto-cleanup
+- Tests: Use pytest `tmp_path` / `tmp_path_factory` fixtures
+- TypeScript/Node: `os.tmpdir()` with unique subdirectories, or `fs.mkdtemp()`
+- Shell scripts: `mktemp -d` for unique temporary directories
+- Build artifacts: Use project-local directories (e.g., `build/`, `dist/`, `.cache/`)
+
+### 6. Anti-Patterns to AVOID
 
 ❌ "I'll add tests later" - Tests are written NOW, not later
 ❌ "This works for the happy path" - Handle ALL paths
@@ -122,7 +139,7 @@ If you cannot complete a task fully:
 ❌ "The build warnings are fine" - Warnings become errors, fix them
 ❌ "Tests are optional for this change" - Tests are NEVER optional
 
-### 6. NEVER Bypass Quality Checks
+### 7. NEVER Bypass Quality Checks
 
 **The following are STRICTLY FORBIDDEN:**
 
@@ -143,7 +160,7 @@ The ONLY acceptable exceptions:
 - Pre-existing ignores that were already in the codebase
 - Genuine false positives with a detailed comment explaining why (requires team approval)
 
-### 7. Use Existing Tooling and Patterns
+### 8. Use Existing Tooling and Patterns
 
 **You MUST use the tools, libraries, and patterns already established in the codebase.**
 
@@ -173,7 +190,7 @@ The ONLY acceptable exceptions:
 
 **The goal is consistency, not perfection. A consistent codebase is maintainable; a patchwork of "best" tools is not.**
 
-### 8. Prefer Modern Open-Source Tools
+### 9. Prefer Modern Open-Source Tools
 
 **When proposing NEW dependencies (with approval), always prefer modern, truly open-source alternatives.**
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -154,6 +154,26 @@ You should:
 
 These rules apply to ALL sub-agents in every phase. Ensure each sub-agent is reminded of these when spawned:
 
+### ALL Tests Must Pass — The Entire Suite, Every Time
+
+**No agent may declare work complete unless the ENTIRE test suite passes.** This is the most critical quality gate.
+
+**"All tests" means:**
+- Every lint rule across the entire codebase (Ruff, ESLint)
+- Every type check across the entire codebase (mypy, TypeScript)
+- Every unit test in every module (pytest, Vitest) — not just tests related to the change
+- Every integration test
+- Every E2E test (Playwright)
+- Coverage thresholds met (≥80%)
+- Build succeeds (frontend `npm run build`)
+
+**This is non-negotiable because CI runs the full suite on every PR.** If any single check fails anywhere, the PR is rejected. There is no concept of "only my tests need to pass."
+
+**When reviewing sub-agent output:**
+- If a Development agent says "all related tests pass" — **send it back**. They must run the FULL suite.
+- If a Quality agent only validates tests for the changed files — **send it back**. They must certify the ENTIRE suite.
+- If any agent reports test failures as "pre-existing" or "unrelated" — **those still must be fixed** before the work is complete.
+
 ### NEVER Use `/tmp` or System Temp Directories
 
 **No agent may write files to `/tmp`, `/var/tmp`, or any hardcoded system temporary directory.** This applies to scripts, tests, CI/CD pipelines, build processes, and runtime code.

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -150,6 +150,21 @@ You should:
 6. Spawn Architecture & Security with Strategy output + original request
 7. Continue through the pipeline...
 
+## Global Rules to Enforce Across All Phases
+
+These rules apply to ALL sub-agents in every phase. Ensure each sub-agent is reminded of these when spawned:
+
+### NEVER Use `/tmp` or System Temp Directories
+
+**No agent may write files to `/tmp`, `/var/tmp`, or any hardcoded system temporary directory.** This applies to scripts, tests, CI/CD pipelines, build processes, and runtime code.
+
+- Python: Use `tempfile.mkdtemp()` or pytest `tmp_path` fixtures
+- TypeScript/Node: Use `os.tmpdir()` with unique subdirs, or `fs.mkdtemp()`
+- Shell: Use `mktemp -d` for unique temporary directories
+- CI/CD: Use runner workspace directories or `$RUNNER_TEMP`
+
+If you see any sub-agent output referencing `/tmp` paths, flag it as a defect and send it back for correction.
+
 ## What You Do NOT Do
 
 - **DO NOT write code yourself** - That's the Development agent's job

--- a/.github/agents/platform-ops.agent.md
+++ b/.github/agents/platform-ops.agent.md
@@ -126,7 +126,24 @@ If you cannot complete a task fully:
 - **DO NOT claim deployment success if health checks fail** - Fix issues first
 - **DO NOT leave monitoring gaps** - Complete observability is required
 
-### 5. Anti-Patterns to AVOID
+### 5. NEVER Use `/tmp` or System Temp Directories
+
+**NEVER write files to `/tmp`, `/var/tmp`, or any system temporary directory.** This applies to ALL contexts: scripts, CI/CD pipelines, deployment automation, build processes, and runtime configurations.
+
+**Why:**
+- `/tmp` is shared across all users and processes — creates security risks (symlink attacks, data leaks)
+- CI/CD runners share `/tmp` across jobs, causing cross-contamination
+- Container builds that rely on `/tmp` create non-reproducible images
+- Sensitive deployment data (secrets, configs) written to `/tmp` may be readable by other processes
+
+**Instead, use:**
+- Shell scripts: `mktemp -d` for unique temporary directories
+- CI/CD pipelines: Use runner-provided workspace directories or `$RUNNER_TEMP`
+- Docker builds: Use build-stage-specific directories
+- Kubernetes: Use `emptyDir` volumes for pod-local temp storage
+- Build artifacts: Use project-local directories (e.g., `build/`, `dist/`, `.cache/`)
+
+### 6. Anti-Patterns to AVOID
 
 ❌ "Monitoring can be added later" - Add it NOW
 ❌ "Alerting is optional for this service" - Alerting is NEVER optional
@@ -135,7 +152,7 @@ If you cannot complete a task fully:
 ❌ "Health checks are passing, so we're done" - Verify ALL criteria, not just health
 ❌ "This works in dev, ship it" - Validate in ALL environments
 
-### 6. NEVER Bypass Quality Checks
+### 7. NEVER Bypass Quality Checks
 
 **The following are STRICTLY FORBIDDEN:**
 
@@ -152,7 +169,7 @@ If you cannot complete a task fully:
 
 **If a deployment or security check fails, FIX THE CONFIGURATION, not the checks.**
 
-### 7. Use Existing Infrastructure Patterns
+### 8. Use Existing Infrastructure Patterns
 
 **You MUST use the infrastructure tools and patterns already established in the codebase.**
 
@@ -181,7 +198,7 @@ If you cannot complete a task fully:
 
 **Consistency in infrastructure is critical for operations. Don't fragment the stack.**
 
-### 8. Prefer Modern Open-Source Tools
+### 9. Prefer Modern Open-Source Tools
 
 **When proposing NEW infrastructure tools (with approval), always prefer modern, truly open-source alternatives.**
 
@@ -211,7 +228,7 @@ If you cannot complete a task fully:
 
 **This protects the project from future licensing issues and ensures operational freedom.**
 
-### 9. Pull Request & GitHub API Best Practices
+### 10. Pull Request & GitHub API Best Practices
 
 **When creating or updating PRs with multi-line markdown bodies**, never pass the content directly as an inline string parameter. Newline characters get stored literally as `\n` on GitHub, breaking all markdown formatting.
 

--- a/.github/agents/quality.agent.md
+++ b/.github/agents/quality.agent.md
@@ -62,6 +62,8 @@ npm run test:e2e                # ALL E2E tests must pass
 
 **If ANY verification step fails, you are NOT done. The code is NOT ready.**
 
+> **CRITICAL: "ALL tests" means the ENTIRE test suite — every test in every module, not just tests related to the current change.** You must validate that lint, type checks, unit tests, integration tests, and E2E tests all pass across the **entire codebase**. A single failure anywhere means the code is NOT certifiable. Do not selectively run only the tests you think are relevant — run the complete suite.
+
 ### 2a. CI Pipeline Requirements
 
 **Tests you write will be validated by the CI pipeline (`.github/workflows/ci.yml`) which enforces a strict stage-based execution:**
@@ -94,29 +96,34 @@ cd frontend && npm run test:e2e && cd ..
 
 **CI will REJECT PRs with failing tests. Coverage below 80% will fail the build.**
 
+> **You are the last quality gate before deployment. Run and validate the ENTIRE test suite — lint, type checks, unit tests, integration tests, coverage, and E2E. If ANY test fails anywhere in the codebase (even tests unrelated to the current change), the code is NOT certifiable. Report ALL failures back to the Development agent.**
+
 ### 3. Definition of Done
 
 A task is **NOT complete** until ALL of the following are true:
-- [ ] All existing tests pass with ZERO failures
+- [ ] **Every test in the entire suite passes with ZERO failures** (not just tests for the current change)
 - [ ] All new code has corresponding tests (≥80% coverage)
 - [ ] All edge cases are tested (null, empty, invalid inputs)
 - [ ] All error scenarios are tested (exceptions, error responses)
-- [ ] All linting rules pass with ZERO violations
-- [ ] All type checks pass with ZERO errors
+- [ ] All linting rules pass with ZERO violations across the **entire codebase**
+- [ ] All type checks pass with ZERO errors across the **entire codebase**
 - [ ] Build succeeds without errors or warnings
 - [ ] Integration tests validate API contracts
 - [ ] E2E tests cover critical user paths (when applicable)
 - [ ] Security tests pass (OWASP Top 10 addressed)
 - [ ] Performance meets SLA requirements
 - [ ] No skipped or pending tests left behind
+- [ ] **Full CI pipeline would pass** (lint → typecheck → all tests → build → E2E)
 
 ### 4. Failure Protocol
 
 If you cannot complete testing fully:
-- **DO NOT certify code with failing tests** - Report failures to Development
+- **DO NOT certify code with failing tests** - Report ALL failures to Development (not just "relevant" ones)
 - **DO NOT skip tests "because they're flaky"** - Fix flaky tests first
 - **DO NOT reduce coverage thresholds** - Add more tests instead
 - **DO NOT approve with known gaps** - Document and escalate gaps
+- **DO NOT selectively run only tests related to the change** - Run the ENTIRE suite
+- **DO NOT ignore pre-existing test failures** - If they fail on the current branch, they block certification
 
 ### 5. NEVER Use `/tmp` or System Temp Directories
 

--- a/.github/agents/quality.agent.md
+++ b/.github/agents/quality.agent.md
@@ -118,7 +118,24 @@ If you cannot complete testing fully:
 - **DO NOT reduce coverage thresholds** - Add more tests instead
 - **DO NOT approve with known gaps** - Document and escalate gaps
 
-### 5. Anti-Patterns to AVOID
+### 5. NEVER Use `/tmp` or System Temp Directories
+
+**NEVER write files to `/tmp`, `/var/tmp`, or any system temporary directory.** This applies to ALL contexts: test output, test fixtures, coverage reports, and any generated files.
+
+**Why:**
+- `/tmp` is shared across all users and processes — creates security risks (symlink attacks, data leaks)
+- Files in `/tmp` may persist across runs, causing flaky tests and non-reproducible results
+- CI/CD runners share `/tmp` across jobs, causing cross-contamination between test runs
+- Sensitive test data written to `/tmp` may be readable by other processes
+
+**Instead, use:**
+- Python tests: Use pytest `tmp_path` / `tmp_path_factory` fixtures (auto-cleaned)
+- TypeScript tests: Use Vitest's built-in temp utilities or `os.tmpdir()` with unique subdirectories
+- Playwright: Configure `outputDir` and `testResults` in project config
+- Shell scripts: `mktemp -d` for unique temporary directories
+- Coverage reports: Use project-local directories (e.g., `coverage/`, `htmlcov/`)
+
+### 6. Anti-Patterns to AVOID
 
 - ❌ "The happy path works" - Test ALL paths
 - ❌ "We'll add more tests later" - Add tests NOW
@@ -129,7 +146,7 @@ If you cannot complete testing fully:
 - ❌ "Security testing takes too long" - Security testing is mandatory
 - ❌ "It passed on my machine" - Verify in CI environment
 
-### 6. NEVER Bypass Quality Checks
+### 7. NEVER Bypass Quality Checks
 
 **The following are STRICTLY FORBIDDEN:**
 
@@ -147,7 +164,7 @@ If you cannot complete testing fully:
 
 **If a quality check fails, the code is NOT ready. Fix the code, not the checks.**
 
-### 7. Use Existing Testing Tools and Patterns
+### 8. Use Existing Testing Tools and Patterns
 
 **You MUST use the testing tools and patterns already established in the codebase.**
 

--- a/.github/agents/strategy-design.agent.md
+++ b/.github/agents/strategy-design.agent.md
@@ -78,7 +78,21 @@ If you cannot complete specifications fully:
 - **DO NOT assume implementation details** - Specify or ask
 - **DO NOT skip stakeholder approval** - Get explicit sign-off
 
-### 5. Anti-Patterns to AVOID
+### 5. NEVER Specify `/tmp` or System Temp Directories in Requirements
+
+**NEVER include `/tmp`, `/var/tmp`, or hardcoded system temporary directory paths in any requirements, specifications, or acceptance criteria.**
+
+**Why:**
+- `/tmp` is shared across all users and processes — creates security risks
+- Hardcoded temp paths make requirements non-portable across environments
+- Development agents may implement the literal path without questioning it
+
+**Instead, specify:**
+- "Use language-appropriate secure temporary file/directory creation" (e.g., Python `tempfile`, Node `fs.mkdtemp`)
+- "Use framework-provided temp fixtures in tests" (e.g., pytest `tmp_path`)
+- "Use project-local directories for build artifacts"
+
+### 6. Anti-Patterns to AVOID
 
 ❌ "Developers will figure out the edge cases" - Document ALL edge cases
 ❌ "UI details TBD" - Complete ALL design details
@@ -89,7 +103,7 @@ If you cannot complete specifications fully:
 ❌ "Break down later" - Break down NOW before handoff
 ❌ "Obvious requirements don't need documentation" - Document EVERYTHING
 
-### 6. NEVER Compromise on Quality Standards
+### 7. NEVER Compromise on Quality Standards
 
 **The following are STRICTLY FORBIDDEN:**
 
@@ -103,7 +117,7 @@ If you cannot complete specifications fully:
 
 **Quality requirements are non-negotiable. If scope needs to change, remove features, not quality.**
 
-### 7. Respect Existing Patterns and Technology Choices
+### 8. Respect Existing Patterns and Technology Choices
 
 **When specifying requirements, work within the established technology stack and patterns.**
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -234,21 +234,23 @@ raise Exception("Not found")
 
 ## Before Submitting Code
 
-Run these checks (or ensure they pass):
+Run these checks (or ensure they pass). **ALL checks must pass across the ENTIRE codebase — not just for files you changed:**
 
 ```bash
-# Backend
+# Backend — run the FULL suite
 cd backend
-ruff check .
-mypy .
-pytest --cov=app --cov-report=term-missing
+ruff check .                    # ALL lint rules, entire codebase
+mypy .                          # ALL type checks, entire codebase
+pytest --cov=app --cov-report=term-missing  # ALL tests, entire suite
 
-# Frontend
+# Frontend — run the FULL suite
 cd frontend
-npm run lint
-npm run test
-npm run test:e2e
+npm run lint                    # ALL lint rules, entire codebase
+npm run test                    # ALL unit tests, entire suite
+npm run test:e2e                # ALL E2E tests
 ```
+
+> **"All tests pass" means every test in every module — not just tests related to your change.** CI runs the complete suite on every PR. A single failure anywhere blocks the entire PR. If your change breaks a test in an unrelated module, it is your responsibility to fix it.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,6 +215,20 @@ raise Exception("Not found")
 - Validate and sanitize all user inputs
 - Use parameterized queries (SQLAlchemy handles this)
 - Apply proper authorization checks on all endpoints
+- **NEVER use `/tmp`, `/var/tmp`, or hardcoded system temp directory paths** — use secure alternatives instead
+
+### Temporary File Handling
+
+**NEVER write to `/tmp` or any hardcoded system temporary directory.** This is a security and reliability requirement.
+
+| Context | Use Instead |
+|---------|-------------|
+| Python code | `tempfile.mkdtemp()`, `tempfile.NamedTemporaryFile()` |
+| pytest tests | `tmp_path` or `tmp_path_factory` fixtures |
+| TypeScript/Node | `os.tmpdir()` with unique subdirs, or `fs.mkdtemp()` |
+| Shell scripts | `mktemp -d` for unique directories |
+| CI/CD pipelines | Runner workspace dirs or `$RUNNER_TEMP` |
+| Build artifacts | Project-local dirs (`build/`, `dist/`, `.cache/`) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Update all agent definitions to prohibit using `/tmp`, `/var/tmp`, or hardcoded system temp paths
- Add guidance for secure alternatives (`tempfile`, `tmp_path`, `fs.mkdtemp`, `mktemp -d`, `$RUNNER_TEMP`, project-local artifact dirs)
- Strengthen agent quality expectations so **ALL tests means the entire suite**, not only tests related to the active change
- Explicitly require full CI workflow success (lint/typecheck/unit/integration/coverage/build/E2E)

## Files Updated
- `.github/agents/architecture-security.agent.md`
- `.github/agents/development.agent.md`
- `.github/agents/quality.agent.md`
- `.github/agents/platform-ops.agent.md`
- `.github/agents/strategy-design.agent.md`
- `.github/agents/orchestrator.agent.md`
- `.github/copilot-instructions.md`

## Why
Agents had started behaving too narrowly around test scope. This change makes quality gates explicit and non-negotiable: if anything fails anywhere in CI, work is not complete.

## Notes
- Documentation/instruction-only change
- No application runtime code changes