### PR TITLE
fix: use POSTGRES_* env vars in migration-check CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,9 @@ jobs:
       - name: Run migrations (first pass)
         working-directory: backend
         env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test_migrations
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test_migrations
         run: |
           uv run alembic upgrade head
           echo "✅ First migration pass successful"
@@ -344,7 +346,9 @@ jobs:
       - name: Run migrations (idempotency check)
         working-directory: backend
         env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test_migrations
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test_migrations
         run: |
           uv run alembic downgrade -1
           uv run alembic upgrade head
@@ -353,7 +357,9 @@ jobs:
       - name: Verify migration history
         working-directory: backend
         env:
-          DATABASE_URL: postgresql://test:test@localhost:5432/test_migrations
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test_migrations
         run: |
           uv run alembic current
           uv run alembic history --verbose | head -20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,11 @@ jobs:
     needs: [backend-coverage]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     
+    env:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: test_migrations
+
     services:
       postgres:
         image: postgres:15
@@ -335,20 +340,12 @@ jobs:
 
       - name: Run migrations (first pass)
         working-directory: backend
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test_migrations
         run: |
           uv run alembic upgrade head
           echo "✅ First migration pass successful"
 
       - name: Run migrations (idempotency check)
         working-directory: backend
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test_migrations
         run: |
           uv run alembic downgrade -1
           uv run alembic upgrade head
@@ -356,10 +353,6 @@ jobs:
 
       - name: Verify migration history
         working-directory: backend
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test_migrations
         run: |
           uv run alembic current
           uv run alembic history --verbose | head -20

--- a/backend/app/services/payment.py
+++ b/backend/app/services/payment.py
@@ -362,7 +362,8 @@ class PaymentService:
 
         Creates or updates the user's subscription.
         """
-        user_id = (session.metadata or {}).get("user_id")
+        metadata = dict(session.metadata) if session.metadata else {}
+        user_id = metadata.get("user_id")
         if not user_id:
             logger.warning("Checkout session missing user_id metadata")
             return
@@ -376,7 +377,7 @@ class PaymentService:
 
         # Get subscription details from Stripe
         stripe_sub = self.stripe.get_subscription(session.subscription)
-        plan_slug = (session.metadata or {}).get("plan_slug", "pro")
+        plan_slug = metadata.get("plan_slug", "pro")
 
         # Update subscription
         if user.subscription:

--- a/backend/app/services/payment.py
+++ b/backend/app/services/payment.py
@@ -363,7 +363,7 @@ class PaymentService:
         Creates or updates the user's subscription.
         """
         metadata: dict[str, str] = (
-            cast(dict[str, str], session.metadata) if session.metadata else {}
+            cast("dict[str, str]", session.metadata) if session.metadata else {}
         )
         user_id = metadata.get("user_id")
         if not user_id:

--- a/backend/app/services/payment.py
+++ b/backend/app/services/payment.py
@@ -362,7 +362,9 @@ class PaymentService:
 
         Creates or updates the user's subscription.
         """
-        metadata = dict(session.metadata) if session.metadata else {}
+        metadata: dict[str, str] = (
+            cast(dict[str, str], session.metadata) if session.metadata else {}
+        )
         user_id = metadata.get("user_id")
         if not user_id:
             logger.warning("Checkout session missing user_id metadata")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "uvicorn[standard]>=0.27.0",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
-    "python-multipart>=0.0.6",
+    "python-multipart>=0.0.26",
     "email-validator>=2.0.0",
     
     # Database
@@ -35,10 +35,10 @@ dependencies = [
     "anthropic>=0.40.0",
     
     # Authentication & Security
-    "PyJWT[crypto]>=2.8.0",  # Replaced python-jose to avoid ecdsa vulnerability
+    "PyJWT[crypto]>=2.12.0",  # Replaced python-jose to avoid ecdsa vulnerability
     "passlib[bcrypt]>=1.7.4",
     "bcrypt>=4.0.0,<4.1.0",  # Pin bcrypt < 4.1 for passlib compatibility
-    "cryptography>=42.0.0",
+    "cryptography>=46.0.7",
     "pyotp>=2.9.0",
     
     # Key Management (Cloud KMS) - Updated for protobuf 5.x support
@@ -55,7 +55,7 @@ dependencies = [
     "stripe>=8.0.0",
     
     # OAuth
-    "authlib>=1.3.0",
+    "authlib>=1.6.11",
     "itsdangerous>=2.1.0",
     
     # PDF Processing
@@ -63,7 +63,7 @@ dependencies = [
     "pdf2image>=1.16.0",
     
     # Image Processing
-    "pillow>=10.0.0",
+    "pillow>=12.2.0",
     "numpy>=1.26.0",
     
     # MFA/QR Code
@@ -92,6 +92,12 @@ dependencies = [
     
     # Security: Fix CVE-2026-0994 by upgrading to protobuf 5.x
     "protobuf>=5.29.6,<6.0.0",
+
+    # Security: minimum versions for transitive dependencies with known CVEs
+    "aiohttp>=3.13.4",
+    "requests>=2.33.0",
+    "pyasn1>=0.6.3",
+    "pygments>=2.20.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

The `Validate Migrations` job in CI has been failing on every run with:
```
asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "postgres"
Role "postgres" does not exist.
```

## Root Cause

`Settings.DATABASE_URL` is a **computed property** built from individual `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` fields. Setting `DATABASE_URL` as an environment variable has no effect — the computed field always constructs the URL from the component fields.

The migration-check job was setting `DATABASE_URL=postgresql://test:test@...`, but Alembic was actually connecting as `postgres:postgres` (the defaults) because the `POSTGRES_*` env vars were never set.

## Fix

Replace the `DATABASE_URL` env var with the individual `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` env vars that the Settings class actually reads.

This also unblocks the **Deploy** workflow, which was being skipped due to CI failures.